### PR TITLE
Add GitHub release binaries for graphix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+          - os: macos-14
+            target: aarch64-apple-darwin
+            archive: tar.gz
+
+    steps:
+      - name: Checkout graphix
+        uses: actions/checkout@v4
+        with:
+          path: graphix
+
+      - name: Checkout netidx
+        uses: actions/checkout@v4
+        with:
+          repository: netidx/netidx
+          path: netidx
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y clang libkrb5-dev libssl-dev pkg-config
+
+      - name: Install macOS build dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install krb5 openssl@3 pkgconf
+          {
+            echo "OPENSSL_DIR=$(brew --prefix openssl@3)"
+            echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix krb5)/lib/pkgconfig"
+          } >> "$GITHUB_ENV"
+
+      - name: Build graphix
+        working-directory: graphix
+        run: cargo build --release --package graphix-shell --bin graphix --target ${{ matrix.target }}
+
+      - name: Package release archive
+        shell: bash
+        working-directory: graphix
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          package="graphix-${version}-${{ matrix.target }}"
+          mkdir -p "dist/${package}"
+          cp "target/${{ matrix.target }}/release/graphix" "dist/${package}/"
+          cp README.md LICENSE "dist/${package}/"
+          cd dist
+          if [[ "${{ matrix.archive }}" == "zip" ]]; then
+            7z a "${package}.zip" "${package}"
+          else
+            tar -czf "${package}.tar.gz" "${package}"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: graphix-${{ matrix.target }}
+          path: graphix/dist/*.tar.gz
+
+  release:
+    name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ block(
 cargo install graphix-shell
 ```
 
-Requires Rust and `clang` / `libkrb5-dev` (Debian/Ubuntu) or `clang-devel` /
-`krb5-devel` (Fedora).
+Requires Rust, `clang`, OpenSSL, Kerberos, and `pkg-config` / `pkgconf`
+development packages.
+
+Tagged releases also publish prebuilt `graphix` binaries on GitHub Releases.
+These archives are intended to make Graphix installable by tools such as
+`mise` without requiring every user to build from source.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary

This adds a GitHub Actions release workflow that builds and publishes prebuilt `graphix` binaries for tagged releases.

The immediate goal is to make Graphix available through GitHub Releases. The longer-term goal is to support installer/tool-version-manager integrations such as `mise use -g graphix` without requiring every user to build `graphix-shell` from source with Cargo.

## Details

- Build the `graphix` binary from the `graphix-shell` package on `v*` tags
- Publish release archives for:
  - `x86_64-unknown-linux-gnu`
  - `aarch64-apple-darwin`
- Checkout `netidx/netidx` as a sibling repository so the existing `../netidx` path dependencies resolve in CI
- Install native build dependencies in CI, including `clang`, Kerberos, OpenSSL, and `pkg-config` / `pkgconf`
- Document that tagged releases publish prebuilt `graphix` binaries

## Notes

The crate is named `graphix-shell`, but the binary declared by the crate is named `graphix`, so the release assets package the `graphix` executable.
